### PR TITLE
Optics correction

### DIFF
--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -146,7 +146,7 @@ class OpticsCorr():
         return np.sqrt(np.sum(res*res)/res.size)
 
     def optics_corr_loco(self,
-                         model,
+                         model=None,
                          goal_model=None,
                          jacobian_matrix=None,
                          nsv=None, nr_max=10, tol=1e-6):
@@ -156,6 +156,8 @@ class OpticsCorr():
         and minimizes the residue vector:
         Delta [Bx@BPM, Bx@CH, By@BPM, By@CV, Dx@BPM, Tunex, Tuney].
         """
+        if model is None:
+            model = self.model
         if jacobian_matrix is None:
             jmat = self.calc_jacobian_matrix(model)
         else:
@@ -195,7 +197,7 @@ class OpticsCorr():
         return OpticsCorr.CORR_STATUS.Sucess
 
     def optics_correction(self,
-                          model,
+                          model=None,
                           goal_model=None,
                           jacobian_matrix=None,
                           nsv=None, nr_max=10, tol=1e-6,
@@ -205,6 +207,8 @@ class OpticsCorr():
         Methods available:
         - LOCO-like correction
         """
+        if model is None:
+            model = self.model
         if method == 'loco':
             result = self.optics_corr_loco(
                 model=model, goal_model=goal_model,

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -141,11 +141,11 @@ class OpticsCorr():
         """Calculate figure of merit from residue vector."""
         return np.sqrt(np.sum(np.abs(res)**2)/res.size)
 
-    def optics_corr(self,
-                    model,
-                    goal_model=None,
-                    jacobian_matrix=None,
-                    nsv=None, nr_max=10, tol=1e-6):
+    def optics_corr_loco(self,
+                         model,
+                         goal_model=None,
+                         jacobian_matrix=None,
+                         nsv=None, nr_max=10, tol=1e-6):
         """Optics correction LOCO-like.
 
         Calculates the pseudo-inverse of optics correction matrix via SVD
@@ -195,3 +195,23 @@ class OpticsCorr():
         else:
             return OpticsCorr.CORR_STATUS.Fail
         return OpticsCorr.CORR_STATUS.Sucess
+
+    def optics_correction(self,
+                          model,
+                          goal_model=None,
+                          jacobian_matrix=None,
+                          nsv=None, nr_max=10, tol=1e-6,
+                          method='loco'):
+        """Optics correction method selection.
+
+        Methods available:
+        - LOCO-like correction
+        """
+        if method == 'loco':
+            result = self.optics_corr_loco(
+                model=model, goal_model=goal_model,
+                jacobian_matrix=jacobian_matrix, nsv=nsv, nr_max=nr_max,
+                tol=tol)
+        else:
+            raise Exception('Chosen method is not implemented!')
+        return result

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -139,7 +139,7 @@ class OpticsCorr():
     @staticmethod
     def get_figm(res):
         """Calculate figure of merit from residue vector."""
-        return np.sqrt(np.sum(np.abs(res)**2)/res.size)
+        return np.sqrt(np.sum(res*res)/res.size)
 
     def optics_corr_loco(self,
                          model,

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -14,11 +14,13 @@ class OpticsCorr():
     METHODS = _namedtuple('Methods', ['Additional', 'Proportional'])(0, 1)
     CORR_STATUS = _namedtuple('CorrStatus', ['Fail', 'Sucess'])(0, 1)
 
-    def __init__(self, model, acc, dim='4d', knobs_list=None, method=None):
+    def __init__(self, model, acc, dim='4d', knobs_list=None,
+                 method=None, correction_method='loco'):
         """."""
         self.model = model
         self.acc = acc
         self.dim = dim
+        self.corr_method = correction_method
         self._method = OpticsCorr.METHODS.Proportional
         self.jacobian_matrix = []
         if self.acc == 'BO':
@@ -200,8 +202,7 @@ class OpticsCorr():
                           model=None,
                           goal_model=None,
                           jacobian_matrix=None,
-                          nsv=None, nr_max=10, tol=1e-6,
-                          method='loco'):
+                          nsv=None, nr_max=10, tol=1e-6):
         """Optics correction method selection.
 
         Methods available:
@@ -209,7 +210,7 @@ class OpticsCorr():
         """
         if model is None:
             model = self.model
-        if method == 'loco':
+        if self.corr_method == 'loco':
             result = self.optics_corr_loco(
                 model=model, goal_model=goal_model,
                 jacobian_matrix=jacobian_matrix, nsv=nsv, nr_max=nr_max,

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -70,7 +70,7 @@ class OpticsCorr():
             return
         if isinstance(value, str):
             self._corr_method = int(
-                value in OpticsCorr.CORR_METHODS._fields[1])
+                value not in OpticsCorr.CORR_METHODS._fields[0])
         elif int(value) in OpticsCorr.CORR_METHODS:
             self._corr_method = int(value)
 

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -132,7 +132,7 @@ class OpticsCorr():
             raise Exception('Missing Delta KL values')
         for idx_mag, mag in enumerate(knobsidx):
             delta = deltas_kl[idx_mag]/len(mag)
-            for _, seg in enumerate(mag):
+            for seg in mag:
                 stren = model[seg].KL
                 if self.method == OpticsCorr.METHODS.Proportional:
                     stren *= (1 + delta)

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -13,14 +13,15 @@ class OpticsCorr():
 
     METHODS = _namedtuple('Methods', ['Additional', 'Proportional'])(0, 1)
     CORR_STATUS = _namedtuple('CorrStatus', ['Fail', 'Sucess'])(0, 1)
+    CORR_METHODS = _namedtuple('CorrMethods', ['LOCO'])(0)
 
     def __init__(self, model, acc, dim='4d', knobs_list=None,
-                 method=None, correction_method='loco'):
+                 method=None, correction_method=None):
         """."""
         self.model = model
         self.acc = acc
         self.dim = dim
-        self.corr_method = correction_method
+        self._corr_method = OpticsCorr.CORR_METHODS.LOCO
         self._method = OpticsCorr.METHODS.Proportional
         self.jacobian_matrix = []
         if self.acc == 'BO':
@@ -37,6 +38,7 @@ class OpticsCorr():
         self.ch_idx = self._get_idx(self.fam_data['CH']['index'])
         self.cv_idx = self._get_idx(self.fam_data['CV']['index'])
         self.method = method
+        self.corr_method = correction_method
 
     @property
     def method(self):
@@ -56,6 +58,26 @@ class OpticsCorr():
     def method_str(self):
         """."""
         return OpticsCorr.METHODS._fields[self._method]
+
+    @property
+    def corr_method(self):
+        """."""
+        return self._corr_method
+
+    @corr_method.setter
+    def corr_method(self, value):
+        if value is None:
+            return
+        if isinstance(value, str):
+            self._corr_method = int(
+                value in OpticsCorr.CORR_METHODS._fields[1])
+        elif int(value) in OpticsCorr.CORR_METHODS:
+            self._corr_method = int(value)
+
+    @property
+    def corr_method_str(self):
+        """."""
+        return OpticsCorr.CORR_METHODS._fields[self._corr_method]
 
     @staticmethod
     def _get_idx(indcs):
@@ -210,7 +232,7 @@ class OpticsCorr():
         """
         if model is None:
             model = self.model
-        if self.corr_method == 'loco':
+        if self.corr_method == OpticsCorr.CORR_METHODS.LOCO:
             result = self.optics_corr_loco(
                 model=model, goal_model=goal_model,
                 jacobian_matrix=jacobian_matrix, nsv=nsv, nr_max=nr_max,

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -131,13 +131,13 @@ class OpticsCorr():
         if deltas_kl is None:
             raise Exception('Missing Delta KL values')
         for idx_mag, mag in enumerate(knobsidx):
-            delta = deltas_kl[idx_mag]
+            delta = deltas_kl[idx_mag]/len(mag)
             for _, seg in enumerate(mag):
                 stren = model[seg].KL
                 if self.method == OpticsCorr.METHODS.Proportional:
-                    stren *= (1 + delta/len(mag))
+                    stren *= (1 + delta)
                 else:
-                    stren += delta/len(mag)
+                    stren += delta
                 model[seg].KL = stren
 
     @staticmethod

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -1,0 +1,161 @@
+"""."""
+
+from copy import deepcopy as _dcopy
+import numpy as np
+
+import pyaccel
+from pymodels import bo, si
+
+
+class OpticsCorr():
+    """."""
+
+    def __init__(self, model, acc, dim='4d', knobs_list=None):
+        """."""
+        self.model = model
+        self.acc = acc
+        self.dim = dim
+        self.jacobian_matrix = []
+        if self.acc == 'BO':
+            self.fam_data = bo.families.get_family_data(self.model)
+        elif self.acc == 'SI':
+            self.fam_data = si.families.get_family_data(self.model)
+        else:
+            raise Exception('Set models: BO or SI')
+        if knobs_list is None:
+            self.knobs_idx = self.fam_data['QN']['index']
+        else:
+            self.knobs_idx = knobs_list
+        self.bpm_idx = self._get_idx(self.fam_data['BPM']['index'])
+        self.ch_idx = self._get_idx(self.fam_data['CH']['index'])
+        self.cv_idx = self._get_idx(self.fam_data['CV']['index'])
+
+    @staticmethod
+    def _get_idx(indcs):
+        return np.array([idx[0] for idx in indcs])
+
+    def calc_jacobian_matrix(self, model=None):
+        """Optics correction response matrix.
+
+        Calculates the variation of Twiss functions and tune given the
+        variation of integrated quadrupoles strength.
+        """
+        if model is None:
+            model = self.model
+
+        res0 = self._get_optics_vector(model)
+        self.jacobian_matrix = np.zeros((res0.size, len(self.knobs_idx)))
+        delta = 1e-6
+
+        modcopy = model[:]
+        for idx, nmag in enumerate(self.knobs_idx):
+            dlt = delta/len(nmag)
+            for seg in nmag:
+                modcopy[seg].KL += dlt
+            res = self._get_optics_vector(modcopy)
+            self.jacobian_matrix[:, idx] = (res-res0)/delta
+            for seg in nmag:
+                modcopy[seg].KL -= dlt
+        return self.jacobian_matrix
+
+    def _get_optics_vector(self, model):
+        twi, *_ = pyaccel.optics.calc_twiss(model)
+        w_beta = 1e2  # order of centimeters
+        w_disp = 1e4  # order of tenth of milimeters
+        w_tune = 1e4  # order of 10^-2
+
+        betax_bpm = twi.betax[self.bpm_idx]
+        betax_ch = twi.betax[self.ch_idx]
+        betay_bpm = twi.betay[self.bpm_idx]
+        betay_cv = twi.betay[self.cv_idx]
+        etax_bpm = twi.etax[self.bpm_idx]
+        tunex = twi.mux[-1]/2/np.pi
+        tuney = twi.muy[-1]/2/np.pi
+
+        vec_bx = np.hstack((betax_bpm, betax_ch))
+        vec_by = np.hstack((betay_bpm, betay_cv))
+        vec_dx = etax_bpm
+        vec_tune = np.hstack((tunex, tuney))
+
+        vec = vec_bx * w_beta / vec_bx.size
+        vec = np.hstack((vec, vec_by * w_beta / vec_by.size))
+        vec = np.hstack((vec, vec_dx * w_disp / vec_dx.size))
+        vec = np.hstack((vec, vec_tune * w_tune / vec_tune.size))
+        return vec
+
+    def get_kl(self, model=None, knobsidx=None):
+        """Return integrated quadrupoles strengths."""
+        if model is None:
+            model = self.model
+        if knobsidx is None:
+            knobsidx = self.knobs_idx
+        kl = []
+        for mag in knobsidx:
+            kl_seg = []
+            for seg in mag:
+                kl_seg.append(model[seg].KL)
+            kl.append(kl_seg)
+        return np.array(kl)
+
+    def set_kl(self, model=None, knobsidx=None, kl=None):
+        """Set integrated quadrupoles strengths in the model."""
+        if model is None:
+            model = self.model
+        if knobsidx is None:
+            knobsidx = self.knobs_idx
+        if kl is None:
+            raise Exception('Missing KL values')
+        newmod = _dcopy(model)
+        for idx_mag, mag in enumerate(knobsidx):
+            for idx_seg, seg in enumerate(mag):
+                newmod[seg].KL = kl[idx_mag][idx_seg]
+        return newmod
+
+    @staticmethod
+    def get_figm(res):
+        """Calculate figure of merit from residue vector."""
+        return np.sqrt(np.sum(np.abs(res)**2)/res.size)
+
+    def optics_corr(self,
+                    model,
+                    goal_model=None,
+                    jacobian_matrix=None,
+                    nsv=None, niter=10, tol=1e-6):
+        """Optics correction LOCO-like.
+
+        Calculates the pseudo-inverse of optics correction matrix via SVD
+        and minimizes the residue vector:
+        Delta [Bx@BPM, Bx@CH, By@BPM, By@CV, Dx@BPM, Tunex, Tuney].
+        """
+        if jacobian_matrix is None:
+            jmat = self.calc_jacobian_matrix(model)
+        else:
+            jmat = _dcopy(jacobian_matrix)
+        umat, smat, vmat = np.linalg.svd(jmat, full_matrices=False)
+        ismat = 1/smat
+        ismat[np.isnan(ismat)] = 0
+        ismat[np.isinf(ismat)] = 0
+        if nsv is not None:
+            ismat[nsv:] = 0
+        ismat = np.diag(ismat)
+        ijmat = np.dot(np.dot(vmat.T, ismat), umat.T)
+        goal_vec = self._get_optics_vector(goal_model)
+        vec = self._get_optics_vector(model)
+        klcorr = self.get_kl(model)
+        dvec = goal_vec - vec
+        bestfigm = OpticsCorr.get_figm(dvec)
+
+        for i in range(niter):
+            dkl = np.dot(ijmat, dvec)
+            klcorr += np.reshape(dkl, (-1, 1))
+            model = self.set_kl(model=model, kl=klcorr)
+            vec = self._get_optics_vector(model)
+            dvec = goal_vec - vec
+            figm = OpticsCorr.get_figm(dvec)
+            print(i, bestfigm)
+            if figm < bestfigm:
+                bestfigm = figm
+            if bestfigm < tol:
+                break
+        print('done!')
+        return model


### PR DESCRIPTION
- LOCO-like optics correction
- All quadrupoles used individually as default
- Additional and proportional methods
- The code minimizes the difference of residue vector which includes betas at BPMs e correctors (betax@CH and betay@CV), horizontal dispersion at BPMs and tunes.
- It is intended that in the next version this code will include optics symmetrization based on the code implemented in AT.