### PR TITLE
Coupling measurement script

### DIFF
--- a/apsuite/commissioning_scripts/base.py
+++ b/apsuite/commissioning_scripts/base.py
@@ -20,6 +20,14 @@ class BaseClass:
         conn &= all([pv.connected for pv in self.pvs.values()])
         return conn
 
+    def wait_for_connection(self, timeout=None):
+        """."""
+        obs = list(self.devices.values()) + list(self.pvs.values())
+        for dev in obs:
+            if not dev.wait_for_connection(timeout=timeout):
+                return False
+        return True
+
     def save_data(self, fname, overwrite=False):
         """."""
         data = dict(params=self.params, data=self.data)

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -17,8 +17,8 @@ class CoupParams():
         """."""
         self.nr_points = 1
         self.time_wait = 5  # s
-        self.neg_percent = 0.1/100
-        self.pos_percent = 0.1/100
+        self.neg_percent = 0.0/100
+        self.pos_percent = 0.0/100
 
     def __str__(self):
         """."""
@@ -88,15 +88,16 @@ class MeasCoupling(BaseClass):
         self.data['current'] = curr_vec
         self.data['tunes'] = tunes_vec
 
-    def process_and_plot_data(self):
+    def process_and_plot_data(self, coup_resolution=None, niter=2000):
         """."""
         _np.random.seed(seed=13101971)
         tune1, tune2 = self.data['tunes'].T
         curr = self.data['current']
 
-        FitTunes.COUPLING_RESOLUTION = 0.2/100
+        if coup_resolution:
+            FitTunes.COUPLING_RESOLUTION = coup_resolution
         fittune = FitTunes(param=curr, tune1=tune1, tune2=tune2)
-        fittune.niter = 2000
+        fittune.niter = niter
         fittune.start(print_flag=False)
         fittune.fitting_plot(oversampling=10, xlabel='QFB Variation [%]')
 

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -36,12 +36,13 @@ class MeasCoupling(BaseClass):
 
     QUAD_PVNAME = 'SI-FAM:PS-QFB'
 
-    def __init__(self):
+    def __init__(self, is_online=True):
         """."""
         super().__init__()
         self.params = CoupParams()
-        self.devices['quad'] = PowerSupply(MeasCoupling.QUAD_PVNAME)
-        self.devices['tune'] = Tune(Tune.DEVICES.SI)
+        if is_online:
+            self.devices['quad'] = PowerSupply(MeasCoupling.QUAD_PVNAME)
+            self.devices['tune'] = Tune(Tune.DEVICES.SI)
         self.data = dict()
         self._stopevt = _Event()
         self._thread = _Thread(target=self._do_meas, daemon=True)

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -199,7 +199,7 @@ class MeasCoupling(BaseClass):
             hspace=0.5, wspace=0.35)
         axi = _plt.subplot(grid[0, 0])
 
-        axi.set_xlabel(f'{anl["qname"]} Current [A]')
+        axi.set_xlabel(f'{self.data["qname"]} Current [A]')
         axi.set_ylabel('Transverse Tunes')
         fig.suptitle('Transverse Linear Coupling: ({:.2f} ± {:.2f}) %'.format(
             fit_vec[-1]*100, anl['fitting_error'][-1] * 100))

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -215,13 +215,11 @@ class MeasCoupling(BaseClass):
         coeff1, offset1, coeff2, offset2, coupling = params
         fx_ = coeff1 * curr + offset1
         fy_ = coeff2 * curr + offset2
-        tune1, tune2 = _np.zeros(curr.shape), _np.zeros(curr.shape)
-        for idx, _ in enumerate(curr):
-            mat = _np.array([[fx_[idx], coupling/2], [coupling/2, fy_[idx]]])
-            eigvalues, _ = _np.linalg.eig(mat)
-            tune1[idx], tune2[idx] = eigvalues
-            if tune1[idx] <= tune2[idx]:
-                tune1[idx], tune2[idx] = tune2[idx], tune1[idx]
+        coupvec = _np.ones(curr.size) * coupling/2
+        mat = _np.array([[fx_, coupvec], [coupvec, fy_]]).T
+        tune1, tune2 = _np.linalg.eigvalsh(mat).T
+        sel = tune1 <= tune2
+        tune1[sel], tune2[sel] = tune2[sel], tune1[sel]
         return tune1, tune2
 
     @staticmethod

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -119,7 +119,7 @@ class MeasCoupling(BaseClass):
         ini_param = self._calc_init_parms(qcurr, tune1, tune2)
         # least squares using Levenberg-Marquardt minimization algorithm
         fit_param = least_squares(
-            fun=MeasCoupling._err_func, x0=ini_param,
+            fun=self._err_func, x0=ini_param,
             args=(qcurr, tune1, tune2), method='lm')
 
         self.analysis['qcurr'] = qcurr

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -116,6 +116,15 @@ class MeasCoupling(BaseClass):
         """Wait for measurement to finish."""
         self._finished.wait(timeout=timeout)
 
+    def load_and_apply_old_data(self, fname):
+        """."""
+        data = self.load_data(fname)
+        if 'data' in data:
+            self.load_and_apply(fname)
+            return
+        data['timestamp'] = _os.path.getmtime(fname)
+        self.data = data
+
     def _do_meas(self):
         if not self.isonline:
             _log.error(

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -167,17 +167,19 @@ class MeasCoupling(BaseClass):
 
     def process_data(self):
         """."""
+        self.analysis = dict()
         qcurr, tune1, tune2 = self._filter_data()
+        self.analysis['qcurr'] = qcurr
+        self.analysis['tune1'] = tune1
+        self.analysis['tune2'] = tune2
+
         ini_param = self._calc_init_parms(qcurr, tune1, tune2)
+        self.analysis['initial_param'] = ini_param
+
         # least squares using Levenberg-Marquardt minimization algorithm
         fit_param = least_squares(
             fun=self._err_func, x0=ini_param,
             args=(qcurr, tune1, tune2), method='lm')
-
-        self.analysis['qcurr'] = qcurr
-        self.analysis['tune1'] = tune1
-        self.analysis['tune2'] = tune2
-        self.analysis['initial_param'] = ini_param
         self.analysis['fitted_param'] = fit_param
         fit_error = self._calc_fitting_error()
         self.analysis['fitting_error'] = fit_error

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -96,7 +96,7 @@ class MeasCoupling(BaseClass):
             self.params.nr_points)
         tunes_vec = _np.zeros((len(curr_vec), 2))
 
-        print('{:s} current:'.format(quad.devname.dev))
+        print('{:s} current:'.format(quad.devname))
         for idx, curr in enumerate(curr_vec):
             quad.current = curr
             _time.sleep(self.params.time_wait)

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -14,14 +14,30 @@ from .base import BaseClass
 class CouplingParams():
     """."""
 
+    QUADS = (
+        'QFB', 'QFA', 'QDB1', 'QDB2', 'QFP',
+        'QDB1', 'QDB2', 'QDP1', 'QDP2', 'QDA',
+        'Q1', 'Q2', 'Q3', 'Q4')
+
     def __init__(self):
         """."""
-        self.quadfam_name = 'QFB'
+        self._quadfam_name = 'QFB'
         self.nr_points = 21
         self.time_wait = 5  # s
         self.neg_percent = 0.1/100
         self.pos_percent = 0.1/100
         self.coupling_resolution = 0.02/100
+
+    @property
+    def quadfam_name(self):
+        """."""
+        return self._quadfam_name
+
+    @quadfam_name.setter
+    def quadfam_name(self, val):
+        """."""
+        if isinstance(val, str) and val.upper() in self.QUADS:
+            self._quadfam_name = val.upper()
 
     def __str__(self):
         """."""

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -71,7 +71,8 @@ class MeasCoupling(BaseClass):
         """."""
         super().__init__()
         self.params = CouplingParams()
-        if is_online:
+        self.isonline = bool(is_online)
+        if self.isonline:
             self.devices['quad'] = PowerSupply(
                 'SI-Fam:PS-' + self.params.quadfam_name)
             self.devices['tune'] = Tune(Tune.DEVICES.SI)
@@ -98,6 +99,10 @@ class MeasCoupling(BaseClass):
         return self._thread.is_alive()
 
     def _do_meas(self):
+        if not self.isonline:
+            _log.error(
+                'Cannot measure. Object is configured for offline studies.')
+            return
         if self.devices['quad'].devname.dev != self.params.quadfam_name:
             self.devices['quad'] = PowerSupply(
                 'SI-Fam:PS-' + self.params.quadfam_name)

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -1,7 +1,9 @@
 """Coupling Measurement from Minimal Tune Separation."""
 
+import sys as _sys
 import time as _time
 from threading import Thread as _Thread, Event as _Event
+import logging as _log
 import numpy as _np
 from scipy.optimize import least_squares
 import matplotlib.pyplot as _plt
@@ -9,6 +11,16 @@ import matplotlib.gridspec as _mpl_gs
 
 from siriuspy.devices import PowerSupply, Tune
 from .base import BaseClass
+
+# _log.basicConfig(format=)
+root = _log.getLogger()
+root.setLevel(_log.INFO)
+
+handler = _log.StreamHandler(_sys.stdout)
+handler.setLevel(_log.INFO)
+formatter = _log.Formatter('%(levelname)7s ::: %(message)s')
+handler.setFormatter(formatter)
+root.addHandler(handler)
 
 
 class CouplingParams():
@@ -119,15 +131,16 @@ class MeasCoupling(BaseClass):
             self.params.nr_points)
         tunes_vec = _np.zeros((len(curr_vec), 2))
 
-        print('{:s} current:'.format(quad.devname))
+        _log.info(f'{quad.devname:s} current:')
         for idx, curr in enumerate(curr_vec):
             quad.current = curr
             _time.sleep(self.params.time_wait)
             tunes_vec[idx, :] = tunes.tunex, tunes.tuney
-            print('  {:8.4f} A ({:+6.3f} %), nux={:6.4f}, nuy={:6.4f}'.format(
-                curr, (curr/curr0-1)*100,
-                tunes_vec[idx, 0], tunes_vec[idx, 1]))
-        print('Finished!')
+            _log.info(
+                '  {:8.4f} A ({:+6.3f} %), nux={:6.4f}, nuy={:6.4f}'.format(
+                    curr, (curr/curr0-1)*100,
+                    tunes_vec[idx, 0], tunes_vec[idx, 1]))
+        _log.info('Finished!')
         quad.current = curr0
         self.data['timestamp'] = _time.time()
         self.data['qname'] = quad.devname
@@ -246,7 +259,8 @@ class MeasCoupling(BaseClass):
             pcov = pcov * s_sq
         else:
             pcov.fill(_np.nan)
-            print('# of fitting parameters larger than # of data points!')
+            _log.warning(
+                '# of fitting parameters larger than # of data points!')
         return _np.sqrt(_np.diag(pcov))
 
     @staticmethod

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -3,14 +3,14 @@
 import time as _time
 from threading import Thread as _Thread, Event as _Event
 import numpy as _np
+from scipy.optimize import least_squares
 import matplotlib.pyplot as _plt
 
-from .base import BaseClass
-from ..optimization import SimulAnneal as _SimulAnneal
 from siriuspy.devices import PowerSupply, Tune
+from .base import BaseClass
 
 
-class CoupParams():
+class CouplingParams():
     """."""
 
     def __init__(self):
@@ -32,17 +32,30 @@ class CoupParams():
 
 
 class MeasCoupling(BaseClass):
-    """."""
+    """Coupling measurement and fitting.
+
+    tunex = coeff1 * quad_parameter + offset1
+    tuney = coeff2 * quad_parameter + offset2
+
+    tune1, tune2 = Eigenvalues([[tunex, coupling/2], [coupling/2, tuney]])
+
+    fit parameters: coeff1, offset1, coeff2, offset2, coupling
+
+    NOTE: It maybe necessary to add a quadratic quadrupole strength
+          dependency for tunes!
+    """
 
     QUAD_PVNAME = 'SI-FAM:PS-QFB'
+    COUPLING_RESOLUTION = 0.02/100
 
     def __init__(self, is_online=True):
         """."""
         super().__init__()
-        self.params = CoupParams()
+        self.params = CouplingParams()
         if is_online:
             self.devices['quad'] = PowerSupply(MeasCoupling.QUAD_PVNAME)
             self.devices['tune'] = Tune(Tune.DEVICES.SI)
+        self.analysis = dict()
         self.data = dict()
         self._stopevt = _Event()
         self._thread = _Thread(target=self._do_meas, daemon=True)
@@ -89,225 +102,144 @@ class MeasCoupling(BaseClass):
         self.data['current'] = curr_vec
         self.data['tunes'] = tunes_vec
 
-    def process_and_plot_data(self, coup_resolution=None, niter=2000):
+    def process_data(self, coup_resolution=None):
         """."""
-        _np.random.seed(seed=13101971)
-        tune1, tune2 = self.data['tunes'].T
-        curr = self.data['current']
+        qcurr, tune1, tune2 = self._filter_data(coup_resolution)
+        ini_param = self._calc_init_parms(qcurr, tune1, tune2)
+        # least squares using Levenberg-Marquardt minimization algorithm
+        fit_param = least_squares(
+            fun=MeasCoupling._err_func, x0=ini_param,
+            args=(qcurr, tune1, tune2), method='lm')
 
-        if coup_resolution:
-            FitTunes.COUPLING_RESOLUTION = coup_resolution
-        fittune = FitTunes(param=curr, tune1=tune1, tune2=tune2)
-        fittune.niter = niter
-        fittune.start(print_flag=False)
-        fittune.fitting_plot(oversampling=10, xlabel='QFB Variation [%]')
+        self.analysis['qcurr'] = qcurr
+        self.analysis['tune1'] = tune1
+        self.analysis['tune2'] = tune2
+        self.analysis['initial_param'] = ini_param
+        self.analysis['fitted_param'] = fit_param
+        fit_error = self._calc_fitting_error()
+        self.analysis['fitting_error'] = fit_error
 
-
-class FitTunes(_SimulAnneal):
-    """Tune Fit.
-
-    tunex = coeff1 * quad_parameter + offset1
-    tuney = coeff2 * quad_parameter + offset2
-
-    tune1, tune2 = Eigenvalues([[tunex, coupling/2], [coupling/2, tuney]])
-
-    fit parameters: coeff1, offset1, coeff2, offset2, coupling
-
-    Ex.:
-            fittune = FitTunes(
-                param=quad_strengths, tune1=meas_tune1, tune2=meas_tune2)
-            fittune.fitting_plot()
-            fittune.niter = 1000
-            fittune.start()
-            fittune.fitting_plot()
-
-    NOTE: It maybe necessary to add a quadratic quadrupole strength
-          dependency for tunes!
-    """
-
-    COUPLING_RESOLUTION = 0.02/100
-
-    def __init__(self, param, tune1, tune2):
+    def plot_fitting(
+            self, oversampling=1, title=None, xlabel=None, fig=None,
+            save=False, fname=None):
         """."""
-        self._param = _np.asarray(param)
-        self._tune1 = _np.asarray(tune1)
-        self._tune2 = _np.asarray(tune2)
+        anl = self.analysis
+        fit_vec = anl['fitted_param']['x']
+        qcurr, tune1, tune2 = anl['qcurr'], anl['tune1'], anl['tune2']
 
-        # sort tune1 > tune2 at each point
-        sel = self._tune1 <= self._tune2
-        if sel.any():
-            self._param = _np.array(param)
-            self._tune1 = _np.array(tune1)
-            self._tune2 = _np.array(tune2)
-            self._tune1[sel], self._tune2[sel] = \
-                self._tune2[sel], self._tune1[sel]
+        qcurr_interp = _np.interp(
+            _np.arange(0, len(qcurr), 1/oversampling),
+            _np.arange(0, len(qcurr)), qcurr)
 
-        # remove nearly degenerate measurement points
-        dtunes = _np.abs(self._tune1 - self._tune2)
-        sel = _np.where(dtunes < FitTunes.COUPLING_RESOLUTION)[0]
-        self._param = _np.delete(self._param, sel)
-        self._tune1 = _np.delete(self._tune1, sel)
-        self._tune2 = _np.delete(self._tune2, sel)
+        fittune1, fittune2 = MeasCoupling._get_normal_modes(
+            params=fit_vec, curr=qcurr_interp)
 
-        super().__init__(use_thread=False)
-
-    # --- fitting parameters ---
-
-    @property
-    def param(self):
-        """."""
-        return self._param
-
-    @property
-    def tune1(self):
-        """."""
-        return self._tune1
-
-    @property
-    def tune2(self):
-        """."""
-        return self._tune2
-
-    @property
-    def coeff1(self):
-        """."""
-        return self.position[0]
-
-    @coeff1.setter
-    def coeff1(self, value):
-        """."""
-        self.position[0] = value
-
-    @property
-    def offset1(self):
-        """."""
-        return self.position[1]
-
-    @offset1.setter
-    def offset1(self, value):
-        """."""
-        self.position[1] = value
-
-    @property
-    def coeff2(self):
-        """."""
-        return self.position[2]
-
-    @coeff2.setter
-    def coeff2(self, value):
-        """."""
-        self.position[2] = value
-
-    @property
-    def offset2(self):
-        """."""
-        return self.position[3]
-
-    @offset2.setter
-    def offset2(self, value):
-        """."""
-        self.position[3] = value
-
-    @property
-    def coupling(self):
-        """."""
-        return self.position[4]
-
-    @coupling.setter
-    def coupling(self, value):
-        """."""
-        self.position[4] = value
-
-    def calc_obj_fun(self):
-        """."""
-        # print(self.position)
-        coeff1, offset1, coeff2, offset2, coupling = self.position
-        _, tune1, tune2 = \
-            FitTunes.calc_tunes(
-                self._param, coeff1, offset1, coeff2, offset2, coupling)
-        diff = ((tune1 - self._tune1)**2 + (tune2 - self._tune2)**2)**0.5
-        residue = _np.mean(diff)
-        # print(self.position, residue)
-        return residue
-
-    def initialization(self):
-        """."""
-        self._calc_init_parms()
-        coeff1, offset1, coeff2, offset2, _ = self.position
-        self.deltas = _np.array([
-            0.01 * 0.002 * (coeff1 - coeff2),
-            0.01 * 0.002 * (offset1 - offset2),
-            0.01 * 0.002 * (coeff1 - coeff2),
-            0.01 * 0.002 * (offset1 - offset2),
-            0.5 * 0.1/100])
-
-    @staticmethod
-    def calc_tunes(
-            param=None,
-            coeff1=None, offset1=None,
-            coeff2=None, offset2=None, coupling=None):
-        """."""
-        fx_ = coeff1 * param + offset1
-        fy_ = coeff2 * param + offset2
-        tune1, tune2 = _np.zeros(param.shape), _np.zeros(param.shape)
-        for i in range(len(param)):
-            mat = _np.array([[fx_[i], coupling/2], [coupling/2, fy_[i]]])
-            eigvalues, _ = _np.linalg.eig(mat)
-            tune1[i], tune2[i] = eigvalues
-            if tune1[i] <= tune2[i]:
-                tune1[i], tune2[i] = tune2[i], tune1[i]
-        return param, tune1, tune2
-
-    def fitting_plot(
-            self, oversampling=1, title=None, xlabel=None, fig=None):
-        """."""
-        position = self.position
-        param = _np.interp(
-            _np.arange(0, len(self._param), 1/oversampling),
-            _np.arange(0, len(self._param)),
-            self._param)
-
-        # NOTE: do error estimate properly!
-        coup_error = self.calc_obj_fun()
-
+        if fig is None:
+            fig = _plt.figure(figsize=(8, 6))
         if xlabel is None:
             xlabel = 'Quadrupole Integrated Strength [1/m]'
         if title is None:
-            title = 'Transverse Linear Coupling: {:.2f} ± {:.2f}%'.format(
-                position[-1] * 100, coup_error * 100)
-
-        prop_cycle = _plt.rcParams['axes.prop_cycle']
-        colors = prop_cycle.by_key()['color']
-        if fig is None:
-            fig = _plt.figure()
-        param, fittune1, fittune2 = FitTunes.calc_tunes(param, *position)
+            title = 'Transverse Linear Coupling: ({:.2f} ± {:.2f}) %'.format(
+                fit_vec[-1]*100, anl['fitting_error'][-1] * 100)
 
         # plot meas data
-        _plt.plot(
-            self._param, self._tune1, 'o', color=colors[0],
-            label='measurement')
-        _plt.plot(self._param, self._tune2, 'o', color=colors[0])
+        _plt.plot(qcurr, tune1, 'o', color='C0', label=r'$\nu_1$')
+        _plt.plot(qcurr, tune2, 'o', color='C1', label=r'$\nu_2$')
 
         # plot fitting
-        _plt.plot(param, fittune1, color=colors[1], label='fitting')
-        _plt.plot(param, fittune2, color=colors[1])
+        _plt.plot(qcurr_interp, fittune1, color='tab:gray', label='fitting')
+        _plt.plot(qcurr_interp, fittune2, color='tab:gray')
         _plt.legend()
         _plt.xlabel(xlabel)
         _plt.ylabel('Transverse Tunes')
         _plt.title(title)
-        _plt.grid()
+        _plt.grid(ls='--', alpha=0.5)
+        _plt.tight_layout(True)
+        if save:
+            if fname is None:
+                date_string = _time.strftime("%Y-%m-%d-%H:%M")
+                fname = 'coupling_fitting_{}.png'.format(date_string)
+            _plt.savefig(fname, format='png', dpi=300)
         _plt.show()
 
-    def _calc_init_parms(self):
-        """."""
-        parm = self._param
-        vyb = self._tune1[0], self._tune2[0]
-        vye = self._tune1[-1], self._tune2[-1]
-        dparm = parm[-1] - parm[0]
-        coeff1 = (min(vye) - max(vyb)) / dparm
-        offset1 = max(vyb) - coeff1 * parm[0]
-        coeff2 = (max(vye) - min(vyb)) / dparm
-        offset2 = min(vyb) - coeff2 * parm[0]
-        coupling = min(_np.abs(self._tune1 - self._tune2))
-        position = [coeff1, offset1, coeff2, offset2, coupling]
-        self.position = position
+    def _filter_data(self, coup_resolution=None):
+        qcurr = _np.asarray(self.data['current'])
+        tune1, tune2 = self.data['tunes'].T
+        tune1 = _np.asarray(tune1)
+        tune2 = _np.asarray(tune2)
+
+        # sort tune1 > tune2 at each point
+        sel = tune1 <= tune2
+        if sel.any():
+            tune1[sel], tune2[sel] = tune2[sel], tune1[sel]
+
+        if coup_resolution:
+            MeasCoupling.COUPLING_RESOLUTION = coup_resolution
+
+        # remove nearly degenerate measurement points
+        dtunes = _np.abs(tune1 - tune2)
+        sel = _np.where(dtunes < MeasCoupling.COUPLING_RESOLUTION)[0]
+        qcurr = _np.delete(qcurr, sel)
+        tune1 = _np.delete(tune1, sel)
+        tune2 = _np.delete(tune2, sel)
+        return qcurr, tune1, tune2
+
+    def _calc_fitting_error(self):
+        # based on fitting error calculation of scipy.optimization.curve_fit
+        # do Moore-Penrose inverse discarding zero singular values.
+        fit_params = self.analysis['fitted_param']
+        _, smat, vhmat = _np.linalg.svd(
+            fit_params['jac'], full_matrices=False)
+        thre = _np.finfo(float).eps * max(fit_params['jac'].shape)
+        thre *= smat[0]
+        smat = smat[smat > thre]
+        vhmat = vhmat[:smat.size]
+        pcov = _np.dot(vhmat.T / smat*smat, vhmat)
+
+        # multiply covariance matrix by residue 2-norm
+        ysize = len(fit_params['fun'])
+        cost = 2 * fit_params['cost']  # res.cost is half sum of squares!
+        popt = fit_params['x']
+        if ysize > popt.size:
+            # normalized by degrees of freedom
+            s_sq = cost / (ysize - popt.size)
+            pcov = pcov * s_sq
+        else:
+            pcov.fill(_np.nan)
+            print('# of fitting parameters larger than # of data points!')
+        return _np.sqrt(_np.diag(pcov))
+
+    # static methods
+    @staticmethod
+    def _get_normal_modes(params, curr):
+        coeff1, offset1, coeff2, offset2, coupling = params
+        fx_ = coeff1 * curr + offset1
+        fy_ = coeff2 * curr + offset2
+        tune1, tune2 = _np.zeros(curr.shape), _np.zeros(curr.shape)
+        for idx, _ in enumerate(curr):
+            mat = _np.array([[fx_[idx], coupling/2], [coupling/2, fy_[idx]]])
+            eigvalues, _ = _np.linalg.eig(mat)
+            tune1[idx], tune2[idx] = eigvalues
+            if tune1[idx] <= tune2[idx]:
+                tune1[idx], tune2[idx] = tune2[idx], tune1[idx]
+        return tune1, tune2
+
+    @staticmethod
+    def _err_func(params, qcurr, tune1, tune2):
+        tune1f, tune2f = MeasCoupling._get_normal_modes(params, qcurr)
+        return _np.sqrt((tune1f - tune1)**2 + (tune2f - tune2)**2)
+
+    @staticmethod
+    def _calc_init_parms(curr, tune1, tune2):
+        nu_beg = tune1[0], tune2[0]
+        nu_end = tune1[-1], tune2[-1]
+        dcurr = curr[-1] - curr[0]
+        # estimative based on
+        # nux = coeff1 * curr + offset1
+        # nuy = coeff2 * curr + offset2
+        coeff1 = (min(nu_end) - max(nu_beg)) / dcurr
+        offset1 = max(nu_beg) - coeff1 * curr[0]
+        coeff2 = (max(nu_end) - min(nu_beg)) / dcurr
+        offset2 = min(nu_beg) - coeff2 * curr[0]
+        coupling = min(_np.abs(tune1 - tune2))
+        return [coeff1, offset1, coeff2, offset2, coupling]

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -194,7 +194,7 @@ class MeasCoupling(BaseClass):
         thre *= smat[0]
         smat = smat[smat > thre]
         vhmat = vhmat[:smat.size]
-        pcov = _np.dot(vhmat.T / smat*smat, vhmat)
+        pcov = _np.dot(vhmat.T / (smat*smat), vhmat)
 
         # multiply covariance matrix by residue 2-norm
         ysize = len(fit_params['fun'])

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -139,6 +139,8 @@ class MeasCoupling(BaseClass):
 
         _log.info(f'{quad.devname:s} current:')
         for idx, curr in enumerate(curr_vec):
+            if self._stopevt.is_set():
+                break
             quad.current = curr
             _time.sleep(self.params.time_wait)
             tunes_vec[idx, :] = tunes.tunex, tunes.tuney

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -104,8 +104,8 @@ class MeasCoupling(BaseClass):
             _time.sleep(self.params.time_wait)
             tunes_vec[idx, :] = tunes.tunex, tunes.tuney
             print('  {:8.4f} A ({:+6.3f} %), nux={:6.4f}, nuy={:6.4f}'.format(
-                curr, (curr/curr0-1)*100),
-                tunes_vec[idx, 0], tunes_vec[idx, 1])
+                curr, (curr/curr0-1)*100,
+                tunes_vec[idx, 0], tunes_vec[idx, 1]))
         print('Finished!')
         quad.current = curr0
         self.data['timestamp'] = _time.time()

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -152,8 +152,7 @@ class MeasCoupling(BaseClass):
         self.analysis['fitting_error'] = fit_error
 
     def plot_fitting(
-            self, oversampling=10, title=None, xlabel=None,
-            save=False, fname=None):
+            self, oversampling=10, save=False, fname=None):
         """."""
         anl = self.analysis
         fit_vec = anl['fitted_param']['x']
@@ -169,12 +168,10 @@ class MeasCoupling(BaseClass):
             hspace=0.5, wspace=0.35)
         axi = _plt.subplot(grid[0, 0])
 
-        if xlabel is None:
-            xlabel = 'Quadrupole Integrated Strength [1/m]'
-        if title is None:
-            title = 'Transverse Linear Coupling: ({:.2f} ± {:.2f}) %'.format(
-                fit_vec[-1]*100, anl['fitting_error'][-1] * 100)
-        fig.suptitle(title)
+        axi.set_xlabel(f'{anl["qname"]} Current [A]')
+        axi.set_ylabel('Transverse Tunes')
+        fig.suptitle('Transverse Linear Coupling: ({:.2f} ± {:.2f}) %'.format(
+            fit_vec[-1]*100, anl['fitting_error'][-1] * 100))
 
         # plot meas data
         axi.plot(qcurr, tune1, 'o', color='C0', label=r'$\nu_1$')
@@ -183,9 +180,7 @@ class MeasCoupling(BaseClass):
         # plot fitting
         axi.plot(qcurr_interp, fittune1, color='tab:gray', label='fitting')
         axi.plot(qcurr_interp, fittune2, color='tab:gray')
-        axi.legend()
-        axi.set_xlabel(xlabel)
-        axi.set_ylabel('Transverse Tunes')
+        axi.legend(loc='best')
         if save:
             if fname is None:
                 date_string = _time.strftime("%Y-%m-%d-%H:%M")

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -97,6 +97,7 @@ class MeasCoupling(BaseClass):
     def start(self):
         """."""
         if self.ismeasuring:
+            _log.error('There is another measurement happening.')
             return
         self._stopevt.clear()
         self._finished.clear()

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -1,9 +1,11 @@
 """Coupling Measurement from Minimal Tune Separation."""
 
 import sys as _sys
+import os as _os
 import time as _time
 from threading import Thread as _Thread, Event as _Event
 import logging as _log
+
 import numpy as _np
 from scipy.optimize import least_squares
 import matplotlib.pyplot as _plt

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -88,6 +88,8 @@ class MeasCoupling(BaseClass):
 
         quad = self.devices['quad']
         tunes = self.devices['tune']
+        quad.wait_for_connection()
+        tunes.wait_for_connection()
 
         curr0 = quad.current
         curr_vec = curr0 * _np.linspace(

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -82,7 +82,7 @@ class MeasCoupling(BaseClass):
         return self._thread.is_alive()
 
     def _do_meas(self):
-        if self.devices['quad'].devname != self.params.quadfam_name:
+        if self.devices['quad'].devname.dev != self.params.quadfam_name:
             self.devices['quad'] = PowerSupply(
                 'SI-Fam:PS-' + self.params.quadfam_name)
 
@@ -96,7 +96,7 @@ class MeasCoupling(BaseClass):
             self.params.nr_points)
         tunes_vec = _np.zeros((len(curr_vec), 2))
 
-        print('{:s} current:'.format(quad.devname))
+        print('{:s} current:'.format(quad.devname.dev))
         for idx, curr in enumerate(curr_vec):
             quad.current = curr
             _time.sleep(self.params.time_wait)
@@ -111,9 +111,9 @@ class MeasCoupling(BaseClass):
         self.data['current'] = curr_vec
         self.data['tunes'] = tunes_vec
 
-    def process_data(self, coup_resolution=None):
+    def process_data(self):
         """."""
-        qcurr, tune1, tune2 = self._filter_data(coup_resolution)
+        qcurr, tune1, tune2 = self._filter_data()
         ini_param = self._calc_init_parms(qcurr, tune1, tune2)
         # least squares using Levenberg-Marquardt minimization algorithm
         fit_param = least_squares(
@@ -174,7 +174,7 @@ class MeasCoupling(BaseClass):
             fig.savefig(fname, format='png', dpi=300)
         return fig, axi
 
-    def _filter_data(self, coup_resolution=None):
+    def _filter_data(self):
         qcurr = _np.asarray(self.data['current'])
         tune1, tune2 = self.data['tunes'].T
         tune1 = _np.asarray(tune1)
@@ -184,9 +184,6 @@ class MeasCoupling(BaseClass):
         sel = tune1 <= tune2
         if sel.any():
             tune1[sel], tune2[sel] = tune2[sel], tune1[sel]
-
-        if coup_resolution:
-            self.params.coupling_resolution = coup_resolution
 
         # remove nearly degenerate measurement points
         dtunes = _np.abs(tune1 - tune2)

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -131,7 +131,7 @@ class MeasCoupling(BaseClass):
         self.analysis['fitting_error'] = fit_error
 
     def plot_fitting(
-            self, oversampling=1, title=None, xlabel=None,
+            self, oversampling=10, title=None, xlabel=None,
             save=False, fname=None):
         """."""
         anl = self.analysis

--- a/apsuite/commissioning_scripts/meas_coupling_tune.py
+++ b/apsuite/commissioning_scripts/meas_coupling_tune.py
@@ -91,6 +91,7 @@ class MeasCoupling(BaseClass):
         self.analysis = dict()
         self.data = dict()
         self._stopevt = _Event()
+        self._finished = _Event()
         self._thread = _Thread(target=self._do_meas, daemon=True)
 
     def start(self):
@@ -98,6 +99,7 @@ class MeasCoupling(BaseClass):
         if self.ismeasuring:
             return
         self._stopevt.clear()
+        self._finished.clear()
         self._thread = _Thread(target=self._do_meas, daemon=True)
         self._thread.start()
 
@@ -109,6 +111,10 @@ class MeasCoupling(BaseClass):
     def ismeasuring(self):
         """."""
         return self._thread.is_alive()
+
+    def wait_measurement(self, timeout=None):
+        """Wait for measurement to finish."""
+        self._finished.wait(timeout=timeout)
 
     def _do_meas(self):
         if not self.isonline:
@@ -146,6 +152,7 @@ class MeasCoupling(BaseClass):
         self.data['qname'] = quad.devname
         self.data['current'] = curr_vec
         self.data['tunes'] = tunes_vec
+        self._finished.set()
 
     def process_data(self):
         """."""

--- a/apsuite/commissioning_scripts/measure_bbb_data.py
+++ b/apsuite/commissioning_scripts/measure_bbb_data.py
@@ -103,6 +103,7 @@ class BbBLData(_BaseClass):
         data = self.load_data(fname)
         if not isinstance(data['data'], _np.ndarray):
             self.load_and_apply(fname)
+            return
 
         data.pop('rf_freq')
         data.pop('harmonic_number')

--- a/apsuite/commissioning_scripts/measure_beta.py
+++ b/apsuite/commissioning_scripts/measure_beta.py
@@ -188,7 +188,7 @@ class MeasBeta(BaseClass):
 
     def start(self):
         """."""
-        if self._thread.is_alive():
+        if not self.is_online or self._thread.is_alive():
             return
         self._stopevt.clear()
         self._thread = _Thread(target=self._meas_beta, daemon=True)

--- a/apsuite/commissioning_scripts/measure_beta.py
+++ b/apsuite/commissioning_scripts/measure_beta.py
@@ -95,18 +95,18 @@ class MeasBeta(BaseClass):
     _DEF_TIMEOUT = 60 * 60  # [s]
 
     def __init__(
-            self, model, famdata=None, is_online=True,
+            self, model, famdata=None, isonline=True,
             meas_method=None, calc_method=None, anly_method=None):
         """."""
         super().__init__()
-        self.is_online = is_online
+        self.isonline = isonline
         self.quads_betax = []
         self.quads_betay = []
         self.params = BetaParams()
         self._calc_method = MeasBeta.METHODS.Numeric
         self._meas_method = MeasBeta.MEASUREMENT.Current
         self._anly_method = MeasBeta.ANALYSIS.Excdata
-        if self.is_online:
+        if self.isonline:
             self.devices['tune'] = Tune(Tune.DEVICES.SI)
             self.devices['sofb'] = SOFB(SOFB.DEVICES.SI)
         self.data['quadnames'] = list()
@@ -126,7 +126,7 @@ class MeasBeta(BaseClass):
         self.anly_method = anly_method
         self.famdata = famdata or si.get_family_data(model)
         self._initialize_data()
-        if self.is_online:
+        if self.isonline:
             self._connect_to_objects()
 
     @property
@@ -188,7 +188,7 @@ class MeasBeta(BaseClass):
 
     def start(self):
         """."""
-        if not self.is_online or self._thread.is_alive():
+        if not self.isonline or self._thread.is_alive():
             return
         self._stopevt.clear()
         self._thread = _Thread(target=self._meas_beta, daemon=True)


### PR DESCRIPTION
Including MeasCoupling class that actually drives the measurement. Adapted from the jupyter notebook `meas_coupling` in machstudy_scrips of screens-iocs folder.

Change fitting method to use `scipy.optimization.least_squares`, which is faster and provides a better fit as compared to Simulated Annealing used previously.

Simulated Annealing:
`684 ms ± 4.43 ms per loop / residue: 1.4e-4`

Least Squares (Scipy):
`37.1 ms ± 241 µs per loop / residue: 7.4e-5`