### PR TITLE
TurnOff CHs subset with stored beam 

### DIFF
--- a/apsuite/commisslib/turnoff_correctors.py
+++ b/apsuite/commisslib/turnoff_correctors.py
@@ -254,7 +254,7 @@ class TurnOffCorr(_ThreadBaseClass):
         """Ramp down and turn off CHs subset while keeping stored beam.
 
         Perform the process of ramping down the kicks for a list of specific
-        horizontal correctors until zero current and then turn off its power
+        horizontal correctors until zero current and then turn off their power
         supplies, while correcting COD and tunes.
 
         At each iteration:
@@ -271,7 +271,7 @@ class TurnOffCorr(_ThreadBaseClass):
         is applied at the same time. Therefore params.max_delta_orbit admits
         some flexibility.
 
-        Once CHs kicks reach zero, then its power supplies are turned off.
+        Once CHs kicks reach zero, then their power supplies are turned off.
         If a beam dump occurs during the process, it will be aborted.
         """
         tune, tunecorr = self.devices['tune'], self.devices['tunecorr']

--- a/apsuite/commisslib/turnoff_correctors.py
+++ b/apsuite/commisslib/turnoff_correctors.py
@@ -263,8 +263,8 @@ class TurnOffCorr(_ThreadBaseClass):
         maximum orbit distortion given by params.max_delta_orbit.
         The actual COD after each kick reduction is always smaller than
         params.max_delta_orbit since the compensation with the remaining CHs
-        is applied at the same time. Therefore some params.max_delta_orbit
-        admits some flexibility.
+        is applied at the same time. Therefore params.max_delta_orbit admits
+        some flexibility.
 
         Once CHs kicks reach zero, then its power supplies are turned off.
         If a beam dump occurs during the process, it will be aborted.

--- a/apsuite/commisslib/turnoff_correctors.py
+++ b/apsuite/commisslib/turnoff_correctors.py
@@ -129,15 +129,15 @@ class TurnOffCorr(_ThreadBaseClass):
     def get_orbit_data(self):
         """Get orbit data from BPMs in Monit1 acquisiton rate.
 
-        BPMs must be configure to listen to Study event and the Study event
+        BPMs must be configured to listen Study event and the Study event
         must be in External mode.
 
-        Saves a data dict in self.data with the following keys:
+        Saves a dict data in self.data with the following keys:
             - timestamp
             - chs_off: names of CHs turned off during the measurement
             - stored_current
-            - orbx: horizontal orbit data - (160, nsamples) array
-            - orby: vertical orbit data - (160, nsamples) array
+            - orbx: horizontal orbit (nsamples x 160)
+            - orby: vertical orbit (nsamples x 160)
             - tunex: horizontal betatron tune
             - tuney: vertical betatron tune
             - mt_acq_rate: MultiTurn acquision rate (always Monit1)

--- a/apsuite/commisslib/turnoff_correctors.py
+++ b/apsuite/commisslib/turnoff_correctors.py
@@ -68,6 +68,46 @@ class TurnOffCorr(_ThreadBaseClass):
         if self.isonline:
             self._create_devices()
             self.respmat = self.devices['sofb'].respmat
+    @property
+    def respmat(self):
+        """."""
+        return self._respmat
+
+    @respmat.setter
+    def respmat(self, value):
+        self._respmat = value
+
+    @property
+    def initial_kicks(self):
+        """."""
+        return self._initial_kicks
+
+    @initial_kicks.setter
+    def initial_kicks(self, value):
+        self._initial_kicks = value
+
+    @property
+    def initial_tunex(self):
+        """."""
+        return self._initial_tunex
+
+    @initial_tunex.setter
+    def initial_tunex(self, value):
+        self._initial_tunex = value
+
+    @property
+    def initial_tuney(self):
+        """."""
+        return self._initial_tuney
+
+    @initial_tuney.setter
+    def initial_tuney(self, value):
+        self._initial_tuney = value
+
+    @property
+    def nr_chs(self):
+        """."""
+        return len(self.sofb_data.ch_names)
 
     def _create_devices(self):
         self.devices.update(

--- a/apsuite/commisslib/turnoff_correctors.py
+++ b/apsuite/commisslib/turnoff_correctors.py
@@ -1,0 +1,173 @@
+"""."""
+import time as _time
+import numpy as _np
+from siriuspy.devices import PowerSupply, CurrInfoSI, Tune, TuneCorr, SOFB
+from siriuspy.sofb.csdev import SOFBFactory
+
+from ..utils import ParamsBaseClass as _ParamsBaseClass, \
+    ThreadedMeasBaseClass as _ThreadBaseClass
+
+
+class TurnOffCorrParams(_ParamsBaseClass):
+    """."""
+
+    def __init__(self):
+        """."""
+        super().__init__()
+        self.max_kick_step = 30  # [urad]
+        self.min_orbres = 5  # [um]
+        self.max_tunex_var = 0.005
+        self.max_tuney_var = 0.005
+        self.chs_idx = []
+        self.cvs_idx = []
+        self.nr_orbcorrs = 5
+        self.wait_tunecorr = 3  # [s]
+
+    def __str__(self):
+        """."""
+        ftmp = '{0:24s} = {1:9.3f}  {2:s}\n'.format
+        dtmp = '{0:24s} = {1:9d}  {2:s}\n'.format
+        stmp = '{0:24s} = {1:9s}  {2:s}\n'.format
+
+        stg = ''
+        stg += ftmp('max_kick_step', self.max_kick_step, '')
+        stg += ftmp('min_orbres', self.min_orbres, '')
+        stg += ftmp('max_tunex_var', self.max_tunex_var, '')
+        stg += ftmp('max_tuney_var', self.max_tuney_var, '')
+        stg += stmp('chs_idx', str(self.chs_idx), '')
+        stg += stmp('cvs_idx', str(self.chs_idx), '')
+        stg += dtmp('nr_orbcorrs', self.nr_orbcorrs, '')
+        stg += ftmp('wait_tunecorr', self.wait_tunecorr, '[s]')
+        return stg
+
+
+class TurnOffCorr(_ThreadBaseClass):
+    """."""
+
+    def __init__(self, params=None, isonline=True):
+        """."""
+        params = TurnOffCorrParams() if params is None else params
+        super().__init__(
+            params=params, target=self._do_measure, isonline=isonline)
+        self.sofb_data = SOFBFactory.create('SI')
+        self.chs_subset = self.sofb_data.ch_names[self.params.chs_idx]
+        self.cvs_subset = self.sofb_data.cv_names[self.params.cvs_idx]
+        self.tunex0, self.tuney0 = None, None
+        if self.isonline:
+            self._create_devices()
+
+    def _create_devices(self):
+        self.devices.update({
+            nme: PowerSupply(nme) for nme in self.chs_subset})
+        self.devices.update({
+            nme: PowerSupply(nme) for nme in self.cvs_subset})
+        self.devices['currinfo'] = CurrInfoSI()
+        self.devices['tune'] = Tune(Tune.DEVICES.SI)
+        self.devices['tunecorr'] = TuneCorr(TuneCorr.DEVICES.SI)
+        self.devices['tunecorr'].cmd_update_reference()
+        self.devices['sofb'] = SOFB(SOFB.DEVICES.SI)
+
+    def get_orbit_data(self):
+        """."""
+        return NotImplementedError
+
+    def check_tunes(self):
+        """."""
+        tunecorr, tune = self.devices['tunecorr'], self.devices['tune']
+        sofb = self.devices['sofb']
+        prms = self.params
+
+        dnux0, dnuy0 = tunecorr.delta_tunex, tunecorr.delta_tuney
+        dnux = self.tunex0 - tune.tunex
+        dnuy = self.tuney0 - tune.tuney
+        cond = abs(dnux) > prms.max_tunex_var
+        cond |= abs(dnuy) > prms.max_tuney_var
+        if cond:
+            print('Tune Correction...')
+            print(f'DeltaTunex: {dnux0:.4f}, DeltaTuneY: {dnuy0:.4f}')
+            tunecorr.delta_tunex = dnux0 + dnux
+            tunecorr.delta_tuney = dnuy0 + dnuy
+            tunecorr.cmd_apply_delta()
+            _time.sleep(prms.wait_tune_corr)
+            sofb.correct_orbit_manually(
+                        nr_iters=prms.nr_orbcorrs, res=prms.min_orbres)
+
+    @staticmethod
+    def apply_corr_ramp(self, corr, ramp):
+        """."""
+        sofb = self.devices['sofb']
+        prms = self.params
+        for kick in ramp:
+            corr.kick = kick
+            sofb.correct_orbit_manually(
+                nr_iters=prms.nr_orbcorrs, res=prms.min_orbres)
+            self.check_tunes()
+
+    def do_single_corr(self, corr_name):
+        """."""
+        sofb, prms = self.devices['sofb'], self.params
+        corr_dev = self.devices[corr_name]
+        if 'CH' in corr_name:
+            names = self.sofb_data.ch_names
+            enbllist0 = sofb.chenbl.copy()
+        else:
+            names = self.sofb_data.cv_names
+            enbllist0 = sofb.cvenbl.copy()
+
+        corr_idx = names.index(corr_name)
+        corr_enbl = enbllist0.copy()
+        corr_enbl[corr_idx] = 0
+        if 'CH' in corr_name:
+            sofb.chenbl = corr_enbl
+        else:
+            sofb.cvenbl = corr_enbl
+        kick0 = corr_dev.kick
+        kickstep = prms.max_kick_step if kick0 < 0 else -prms.max_kick_step
+        rampdown = _np.r_[_np.arange(kick0, 0, kickstep)[1:], 0]
+        self.apply_corr_ramp(corr_dev, rampdown)
+        corr_dev.cmd_turn_off()
+        # Measure Orbit
+        # data = self.get_orbit_data()
+        corr_dev.cmd_turn_on()
+        rampup = _np.r_[rampdown[::-1][1:], kick0]
+        self.apply_corr_ramp(corr_dev, rampup)
+        if 'CH' in corr_name:
+            sofb.chenbl = enbllist0
+        else:
+            sofb.cvenbl = enbllist0
+        # return data
+
+    def _do_measure(self):
+        tune, tunecorr = self.devices['tune'], self.devices['tunecorr']
+        sofb, prms = self.devices['sofb'], self.params
+        excx0, excy0 = tune.enablex, tune.enabley
+        if not excx0:
+            tune.cmd_enablex()
+            _time.sleep(prms.wait_tunecorr)
+        if not excy0:
+            tune.cmd_enabley()
+            _time.sleep(prms.wait_tunecorr)
+
+        self.tunex0, self.tuney0 = tune.tunex, tune.tuney
+        for chname in self.chs_subset:
+            print(chname)
+            # this method will return the data set
+            self.do_single_corr(chname)
+
+        for cvname in self.cvs_subset:
+            print(cvname)
+            # this method will return the data set
+            self.do_single_corr(cvname)
+
+        if not excx0:
+            tune.cmd_disablex()
+        if not excy0:
+            tune.cmd_disabley()
+
+        print('Restoring Quadrupoles Configuration...')
+        tunecorr.delta_tunex = 0
+        tunecorr.delta_tuney = 0
+        tunecorr.cmd_apply_delta()
+        _time.sleep(prms.wait_tune_corr)
+        sofb.correct_orbit_manually(
+                    nr_iters=prms.nr_orbcorrs, res=prms.min_orbres)


### PR DESCRIPTION
Ramp down and turn off CHs subset while keeping stored beam.

Perform the process of ramping down the kicks for a list of specific horizontal correctors until zero current and then turn off its power supplies, while correcting COD and tunes.

At each iteration:
  - calc. expected COD due to reduction in CHs subset
  - calc. kicks in remaining CHs to compensate the expected COD
  - apply kicks that reduces the CHs subset and also compensate COD
  - check betatron tunes drifts and if so, correct the tunes
  - apply a few orbit corrections to minimize the residual COD

Kick variations during the CHs ramping down are limited to produce a maximum orbit distortion given by `params.max_delta_orbit`. The actual COD after each kick reduction is always smaller than `params.max_delta_orbit` since the compensation with the remaining CHs is applied at the same time. Therefore `params.max_delta_orbit` admits some flexibility.

Once CHs kicks reach zero, then its power supplies are turned off.
If a beam dump occurs during the process, it will be aborted.

A method to reverse the process is also available in this class: `restore_initial_state()`.