### PR TITLE
DYNAP. ENH: fix percentage sign in plot label and return all the axes on `ph_space.make_figure()`

### DIFF
--- a/apsuite/dynap/phase_space.py
+++ b/apsuite/dynap/phase_space.py
@@ -264,7 +264,7 @@ class PhaseSpace(_BaseClass):
 
         axx.set_xlabel('X [mm]')
         ayy.set_xlabel('Y [mm]')
-        ade.set_xlabel(r'$\delta$ [%]')
+        ade.set_xlabel(r'$\delta$ [\%]')
         axx.set_ylabel(r'$\Delta\nu$')
 
         axx.legend(loc='best')

--- a/apsuite/dynap/phase_space.py
+++ b/apsuite/dynap/phase_space.py
@@ -269,4 +269,4 @@ class PhaseSpace(_BaseClass):
 
         axx.legend(loc='best')
 
-        return fig, phx, phy, tune
+        return fig, phx, phy, tune, axx, ayy, ade

--- a/apsuite/dynap/phase_space.py
+++ b/apsuite/dynap/phase_space.py
@@ -269,4 +269,4 @@ class PhaseSpace(_BaseClass):
 
         axx.legend(loc='best')
 
-        return fig, phx, phy, tune, axx, ayy, ade
+        return fig, [[phx, phy, tune], [axx, ayy, ade]]


### PR DESCRIPTION
I noticed the label for the energy deviation in the plot produced by the `ph_space.make_figure()` method is always broken. This method returns the figure object and some of the axes plotted in it (`phx` and `phy`). I found it useful to return the other axes as well so I could manipulate them (change labels, colors, style or reuse the subplots elsewhere).