### PR TITLE
Improve AC ORM processing for RF frequency step measurement

### DIFF
--- a/apsuite/commisslib/meas_ac_orm.py
+++ b/apsuite/commisslib/meas_ac_orm.py
@@ -340,7 +340,7 @@ class MeasACORM(_ThreadBaseClass):
 
     def save_loco_input_data(
             self, respmat_name: str, overwrite=False, save2servconf=False,
-            extra_kwargs=None):
+            extra_kwargs=None, matrix=None):
         """Save in `.pickle` format a dictionary with all LOCO input data.
 
         Args:
@@ -364,12 +364,13 @@ class MeasACORM(_ThreadBaseClass):
         data['tuney'] = bpms_anly['tuney']
         data['stored_current'] = bpms_anly['stored_current']
         data['bpm_variation'] = bpms_anly['bpm_variation']
-        mat = self.build_respmat()
-        data['respmat'] = mat
+        if matrix is None:
+            matrix = self.build_respmat()
+        data['respmat'] = matrix
         data.update(extra_kwargs or dict())
         if save2servconf:
             data['orbmat_name'] = respmat_name
-            mat = self.save_respmat_to_configdb(respmat_name, mat=mat)
+            matrix = self.save_respmat_to_configdb(respmat_name, mat=matrix)
         _save(data, f'loco_input_{respmat_name:s}', overwrite=overwrite)
 
     def save_analysis_dictionary(self, filename, overwrite=False):

--- a/apsuite/commisslib/meas_ac_orm.py
+++ b/apsuite/commisslib/meas_ac_orm.py
@@ -1069,7 +1069,7 @@ class MeasACORM(_ThreadBaseClass):
             'mV:AL:REF-SP', 'mV:AMPREF:MIN:S', 'PL:REF:S', 'PHSREF:MIN:S',
             'COND:DC:S', 'COND:DC', 'PULSE:S', 'PULSE',
             ]
-        self.devices['llrf'] = ASLLRF(ASLLRF.DEVICES.SI, props2init=props)
+        self.devices['llrf'] = ASLLRF(ASLLRF.DEVICES.SIA, props2init=props)
         # Create Tune object:
         self.devices['tune'] = Tune(Tune.DEVICES.SI)
         self._log(f'ET: = {_time.time()-t00:.2f}s')
@@ -1577,8 +1577,8 @@ class MeasACORM(_ThreadBaseClass):
         anly['orby_neg'] = orby_neg
         anly['orbx_pos'] = orbx_pos
         anly['orby_pos'] = orby_pos
-        anly['mat_colx'] = (orbx_pos - orbx_neg) / kick / 2
-        anly['mat_coly'] = (orby_pos - orby_neg) / kick / 2
+        anly['mat_colsx'] = (orbx_pos - orbx_neg) / kick / 2
+        anly['mat_colsy'] = (orby_pos - orby_neg) / kick / 2
 
         self._log(f'Done! ET: {_time.time()-t0_:2f}s')
         return anly


### PR DESCRIPTION
During the last studies, we noticed that the processing  for the RF frequency step method for measuring the RF column of the ORM was broken. 

The previous approach consisted on fitting a square waveform to the acquired orbit to identify the step-transitions in orbit due to step RF freq changes. However, the estimated points of transition were often wrong.

The approach I introduce here relies on identifying the transitions points by finding where the orbit is below/above half the estimated orbit change for a given frequency step. 