### PR TITLE
Fix orbcorr cavity

### DIFF
--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -71,8 +71,10 @@ class OrbitCorr:
         else:
             raise ValueError('Corretion system must be "SOFB" or "FOFB"')
         if self.params.enblrf and model.cavity_on is False:
-            raise Exception("It is necessary to turn the cavity on if it is"
-                            " to be used in correction..")
+            raise ValueError(
+                "It is necessary to turn on the cavity if it is "
+                "to be used in correction."
+            )
 
         self.params.enbllistch = _np.ones(
             self.respm.ch_idx.size, dtype=bool)


### PR DESCRIPTION
A possible problem in the orbit correction class:
1) The cavity was always being set as True regardless of the initial state of the model, and the original state was not being restored.
2) The cavity must be set to True when calculating the kicks to correct the orbit if we choose to use the RF correction, so I added a line to set the cavity to True in this function and then restore the original value.