### PR TITLE
Save `bpms2dobba` in BBA data file

### DIFF
--- a/apsuite/commisslib/measure_bba.py
+++ b/apsuite/commisslib/measure_bba.py
@@ -1555,6 +1555,7 @@ class DoBBA(_BaseClass):
 
     # #### private methods ####
     def _do_bba(self):
+        self.data["bpms2dobba"] = self.bpms2dobba
         tini = _datetime.datetime.fromtimestamp(_time.time())
         print(
             "Starting measurement at {:s}".format(


### PR DESCRIPTION
Partner of https://github.com/lnls-sirius/scripts/pull/181

Saves `bpms2dobba` in BBA file so that progress from previous measurements can be recovered by comparing measured vs to-be measured BPMs.