### PR TITLE
Fix orbcorr process kicks

### DIFF
--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -289,8 +289,6 @@ class OrbitCorr:
         ncv = len(cvidx)
 
         kickch, kickcv, kickrf = kicks[:nch], kicks[nch:nch+ncv], kicks[-1]
-        # kickch = kickch[par.enbllistch]
-        # kickcv = kickcv[par.enbllistcv]
 
         cond = _np.any(_np.abs(kickch) >= par.maxkickch)
         cond &= _np.any(_np.abs(kickcv) >= par.maxkickcv)
@@ -303,8 +301,6 @@ class OrbitCorr:
         dkickrf = dkicks[-1]
         maskch = dkickch != 0
         maskcv = dkickcv != 0
-        # dkickch = dkickch[par.enbllistch]
-        # dkickcv = dkickcv[par.enbllistcv]
 
         # apply factor to dkicks in case they are larger than maximum delta:
         coef_ch = min(

--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -303,10 +303,20 @@ class OrbitCorr:
         maskcv = dkickcv != 0
 
         # apply factor to dkicks in case they are larger than maximum delta:
-        coef_ch = min(
-            par.corrgainch, par.maxdeltakickch/_np.abs(dkickch).max())
-        coef_cv = min(
-            par.corrgaincv, par.maxdeltakickcv/_np.abs(dkickcv).max())
+        if maskch.any():
+            coef_ch = min(
+                par.corrgainch,
+                par.maxdeltakickch/_np.abs(dkickch[maskch]).max())
+        else:
+            coef_ch = par.corrgainch
+
+        if maskcv.any():
+            coef_cv = min(
+                par.corrgaincv,
+                par.maxdeltakickcv/_np.abs(dkickcv[maskcv]).max())
+        else:
+            coef_cv = par.corrgaincv
+
         coef_rf = 1.0
         if par.enblrf and dkickrf != 0:
             coef_rf = min(
@@ -320,15 +330,17 @@ class OrbitCorr:
         # has a positive and a negative value. We must consider only
         # the positive one and take the minimum value along the columns
         # to be the multiplicative factor:
-        que = [(-par.maxkickch - kickch[maskch]) / dkickch[maskch], ]
-        que.append((par.maxkickch - kickch[maskch]) / dkickch[maskch])
-        que = _np.max(que, axis=0)
-        coef_ch = max(min(_np.min(que), coef_ch), 0)
+        if maskch.any():
+            que = [(-par.maxkickch - kickch[maskch]) / dkickch[maskch], ]
+            que.append((par.maxkickch - kickch[maskch]) / dkickch[maskch])
+            que = _np.max(que, axis=0)
+            coef_ch = max(min(_np.min(que), coef_ch), 0)
 
-        que = [(-par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv], ]
-        que.append((par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv])
-        que = _np.max(que, axis=0)
-        coef_cv = max(min(_np.min(que), coef_cv), 0)
+        if maskch.any():
+            que = [(-par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv], ]
+            que.append((par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv])
+            que = _np.max(que, axis=0)
+            coef_cv = max(min(_np.min(que), coef_cv), 0)
 
         if self.params.enblrf and dkickrf != 0:
             que = [(-par.maxkickrf - kickrf) / dkickrf, ]

--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -281,19 +281,17 @@ class OrbitCorr:
     def _process_kicks(self, dkicks):
         par = self.params
 
-        chidx = self.respm.ch_idx[par.enbllistch]
-        cvidx = self.respm.cv_idx[par.enbllistcv]
+        chidx = self.respm.ch_idx
+        cvidx = self.respm.cv_idx
 
         # if kicks are larger the maximum tolerated raise error
         kicks = self.get_kicks()
         nch = len(chidx)
         ncv = len(cvidx)
 
-        kickch, kickcv = kicks[:nch], kicks[nch:nch+ncv]
-        kickrf = _np.array([kicks[-1]])
+        kickch, kickcv, kickrf = kicks[:nch], kicks[nch:nch+ncv], kicks[-1]
         kickch = kickch[par.enbllistch]
         kickcv = kickcv[par.enbllistcv]
-        kickrf = kickrf[[par.enblrf]]
 
         cond = _np.any(_np.abs(kickch) >= par.maxkickch)
         cond &= _np.any(_np.abs(kickcv) >= par.maxkickcv)
@@ -304,6 +302,8 @@ class OrbitCorr:
 
         dkickch, dkickcv = dkicks[:nch], dkicks[nch:nch+ncv]
         dkickrf = dkicks[-1]
+        dkickch = dkickch[par.enbllistch]
+        dkickcv = dkickcv[par.enbllistcv]
 
         # apply factor to dkicks in case they are larger than maximum delta:
         coef_ch = min(
@@ -351,7 +351,7 @@ class OrbitCorr:
             dkickrf *= coef_rf
         saturation_flag = _np.isclose(min_coef, 0)
 
-        kicks[:nch] += dkickch
-        kicks[nch:nch+ncv] += dkickcv
+        kicks[:nch][par.enbllistch] += dkickch
+        kicks[nch:nch+ncv][par.enbllistcv] += dkickcv
         kicks[-1] += dkickrf
         return kicks, saturation_flag

--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -279,16 +279,22 @@ class OrbitCorr:
             model[self.respm.rf_idx[0]].frequency = kickrf
 
     def _process_kicks(self, dkicks):
-        chidx = self.respm.ch_idx
-        cvidx = self.respm.cv_idx
-
         par = self.params
+
+        chidx = self.respm.ch_idx[par.enbllistch]
+        cvidx = self.respm.cv_idx[par.enbllistcv]
 
         # if kicks are larger the maximum tolerated raise error
         kicks = self.get_kicks()
         nch = len(chidx)
         ncv = len(cvidx)
-        kickch, kickcv, kickrf = kicks[:nch], kicks[nch:nch+ncv], kicks[-1]
+
+        kickch, kickcv = kicks[:nch], kicks[nch:nch+ncv]
+        kickrf = _np.array([kicks[-1]])
+        kickch = kickch[par.enbllistch]
+        kickcv = kickcv[par.enbllistcv]
+        kickrf = kickrf[[par.enblrf]]
+
         cond = _np.any(_np.abs(kickch) >= par.maxkickch)
         cond &= _np.any(_np.abs(kickcv) >= par.maxkickcv)
         if par.enblrf:


### PR DESCRIPTION
This PR excludes zero dkicks in "que" calculation
The formula used is:
que = (-par.maxkickch - kickch) / dkickch
With this change, any zero in the denominator will be excluded from the "que" calculation.