### PR TITLE
Propagate changes in orbcorr for tracking dimension flag

### DIFF
--- a/apsuite/commisslib/opt_septa_feedforward.py
+++ b/apsuite/commisslib/opt_septa_feedforward.py
@@ -397,7 +397,7 @@ class OptSeptaFF(_RCDS):
         corrs_order = ['M2-CH', 'M1-CH', 'M2-CV', 'M1-CV', 'RF']
         if from_model:
             mod = _si.create_accelerator()
-            respm = _OrbRespmat(mod, acc='SI', dim='6d')
+            respm = _OrbRespmat(mod, acc='SI', use6dtrack=True)
 
             fch = _np.array(respm.fam_data['FCH']['index']).ravel()
             fcv = _np.array(respm.fam_data['FCV']['index']).ravel()

--- a/apsuite/loco/analysis.py
+++ b/apsuite/loco/analysis.py
@@ -97,7 +97,7 @@ class LOCOAnalysis:
         # print('    tunes final : ', tunecorr.get_tunes(simod))
 
         # Get nominal orbit matrix and dispersion
-        matrix_nominal = OrbRespmat(simod, "SI", "6d").get_respm()
+        matrix_nominal = OrbRespmat(simod, "SI", True).get_respm()
 
         alpha0 = pyaccel.optics.get_mcf(simod)
         idx = pyaccel.lattice.find_indices(
@@ -125,7 +125,7 @@ class LOCOAnalysis:
 
         self.loco_fit = loco_data
 
-        matrix_fitting = OrbRespmat(model_fitting, "SI", "6d").get_respm()
+        matrix_fitting = OrbRespmat(model_fitting, "SI", True).get_respm()
         matrix_fitting = LOCOUtils.apply_all_gain(
             matrix_fitting, gain_bpm, roll_bpm, gain_corr
         )

--- a/apsuite/loco/config.py
+++ b/apsuite/loco/config.py
@@ -36,7 +36,7 @@ class LOCOConfig:
         self._minimization = LOCOConfig.MINIMIZATION.GaussNewton
         self._svd_method = LOCOConfig.SVD.Selection
         self.model = None
-        self.dim = None
+        self.use6dtrack = None
         self.respm = None
         self.goalmat = None
         self.measured_dispersion = None
@@ -115,7 +115,7 @@ class LOCOConfig:
         dtmp = "{0:35s}: {1:3d}  {2:s}\n".format
         etmp = "{0:35s}: {1:e}  {2:s}\n".format
 
-        stg = stmp("Tracking dimension", self.dim, "")
+        stg = stmp("Use 6d tracking", self.use6dtrack, "")
         stg += stmp("Include dispersion", self.use_dispersion, "")
         stg += stmp("Include diagonal", self.use_diagonal, "")
         stg += stmp("Include off-diagonal", self.use_offdiagonal, "")
@@ -284,7 +284,7 @@ class LOCOConfig:
 
     def update(self):
         """."""
-        self.update_model(self.model, self.dim)
+        self.update_model(self.model, self.use6dtrack)
         self.update_matrix(self.use_dispersion)
         self.update_goalmat(
             self.goalmat, self.use_dispersion, self.use_offdiagonal
@@ -299,13 +299,15 @@ class LOCOConfig:
         self.update_svd(self.svd_method, self.svd_sel, self.svd_thre)
         self.nr_fit_parameters = self.get_nr_fit_parameters()
 
-    def update_model(self, model, dim):
+    def update_model(self, model, use6dtrack):
         """."""
-        self.dim = dim
+        self.use6dtrack = use6dtrack
         self.model = _dcopy(model)
-        self.model.cavity_on = dim == "6d"
+        self.model.cavity_on = use6dtrack
         self.model.radiation_on = False
-        self.respm = _OrbRespmat(model=self.model, acc=self.acc, dim=self.dim)
+        self.respm = _OrbRespmat(
+            model=self.model, acc=self.acc, use6dtrack=self.use6dtrack
+        )
         self._create_indices()
 
     def update_svd(

--- a/apsuite/loco/report.py
+++ b/apsuite/loco/report.py
@@ -122,7 +122,7 @@ class LOCOReport(FPDF):
         latt_ver = self.loco_data["fit_model"].lattice_version
         data = (
             ("Lattice version", latt_ver),
-            ("Tracking dimension", cfg.dim),
+            ("Use 6D tracking", cfg.use6dtrack),
             ("Include dispersion", cfg.use_dispersion),
             ("Include diagonal blocks", cfg.use_diagonal),
             ("Include off-diagonal blocks", cfg.use_offdiagonal),

--- a/apsuite/optics_analysis/coupling_correction.py
+++ b/apsuite/optics_analysis/coupling_correction.py
@@ -16,14 +16,16 @@ class CouplingCorr():
     CORR_STATUS = _get_namedtuple('CorrStatus', ['Fail', 'Sucess'])
     CORR_METHODS = _get_namedtuple('CorrMethods', ['Orbrespm'])
 
-    def __init__(self, model, acc, dim='4d',
+    def __init__(self, model, acc, use6dtrack=False,
                  skew_list=None, correction_method=None):
         """."""
         self.model = model
         self.acc = acc
-        self.dim = dim
+        self.use6dtrack = use6dtrack
         self._corr_method = None
-        self.respm = OrbRespmat(model=self.model, acc=self.acc, dim=self.dim)
+        self.respm = OrbRespmat(
+            model=self.model, acc=self.acc, use6dtrack=self.use6dtrack
+        )
         self.bpm_idx = self.respm.fam_data['BPM']['index']
         if skew_list is None:
             self.skew_idx = self.respm.fam_data['QS']['index']

--- a/apsuite/optics_analysis/optics_correction.py
+++ b/apsuite/optics_analysis/optics_correction.py
@@ -15,12 +15,12 @@ class OpticsCorr():
     CORR_STATUS = _get_namedtuple('CorrStatus', ['Fail', 'Sucess'])
     CORR_METHODS = _get_namedtuple('CorrMethods', ['LOCO'])
 
-    def __init__(self, model, acc, dim='4d', knobs_list=None,
+    def __init__(self, model, acc, use6dtrack=False, knobs_list=None,
                  method=None, correction_method=None):
         """."""
         self.model = model
         self.acc = acc
-        self.dim = dim
+        self.use6dtrack = use6dtrack
         self._corr_method = OpticsCorr.CORR_METHODS.LOCO
         self._method = OpticsCorr.METHODS.Proportional
         self.jacobian_matrix = []

--- a/apsuite/orbcorr/calc_orbcorr_mat.py
+++ b/apsuite/orbcorr/calc_orbcorr_mat.py
@@ -11,10 +11,10 @@ class OrbRespmat:
     _FREQ_DELTA = 10
     _ENERGY_DELTA = 1e-5
 
-    def __init__(self, model, acc='SI', use6dorb=False, corr_system='SOFB'):
+    def __init__(self, model, acc='SI', use6dtrack=False, corr_system='SOFB'):
         """."""
         self.model = model
-        self.use6dorb = use6dorb
+        self.use6dtrack = use6dtrack
 
         acc = acc.upper()
         if acc not in {'BO', 'SI'}:
@@ -38,10 +38,10 @@ class OrbRespmat:
     def get_respm(self, add_rfline=True):
         """."""
         cav = self.model.cavity_on
-        self.model.cavity_on = self.use6dorb
+        self.model.cavity_on = self.use6dtrack
 
         find_m = pyaccel.tracking
-        find_m = find_m.find_m66 if self.use6dorb else find_m.find_m44
+        find_m = find_m.find_m66 if self.use6dtrack else find_m.find_m44
         m_mat, t_mat = find_m(self.model, indices='open')
 
         nch = len(self.ch_idx)
@@ -150,7 +150,7 @@ class OrbRespmat:
     def _get_rfline(self):
         idx = self.rf_idx[0]
         rffreq = self.model[idx].frequency
-        if self.use6dorb:
+        if self.use6dtrack:
             dfreq = OrbRespmat._FREQ_DELTA
             self.model[idx].frequency = rffreq + dfreq
             orbp = pyaccel.tracking.find_orbit6(self.model, indices='open')

--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -12,7 +12,7 @@ class CorrParams:
 
     RESPMAT_MODE = _get_namedtuple('RespMatMode', ['Full', 'Mxx', 'Myy'])
 
-    def __init__(self, use6dorb=False):
+    def __init__(self, use6dtrack=False):
         """."""
         # The most restrictive of the two below will be the limiting factor:
         self.minsingval = 0.2
@@ -20,7 +20,7 @@ class CorrParams:
         self.tikhonovregconst = 0  # Tikhonov regularization constant
         self.respmatmode = self.RESPMAT_MODE.Full
         self.respmatrflinemult = 1e6  # Mult. factor of RF line in SVD.
-        self._enblrf = use6dorb
+        self._enblrf = use6dtrack
         self.enbllistbpm = None
         self.enbllistch = None
         self.enbllistcv = None
@@ -41,7 +41,7 @@ class CorrParams:
         self.useglobalcoef = False  # Use same kick factor for all correctors.
         self.updatejacobian = False  # jacobian should update in all iterations
 
-        self.use6dorb = use6dorb
+        self.use6dtrack = use6dtrack
 
     @property
     def enblrf(self):
@@ -51,8 +51,8 @@ class CorrParams:
     @enblrf.setter
     def enblrf(self, value):
         val = bool(value)
-        if val is True and self.use6dorb is not True:
-            raise ValueError('Cannot enable RF with use6dorb being False.')
+        if val is True and self.use6dtrack is not True:
+            raise ValueError('Cannot enable RF with use6dtrack being False.')
         self._enblrf = val
 
 
@@ -69,18 +69,18 @@ class OrbitCorr:
         acc,
         params=None,
         corr_system='SOFB',
-        use6dorb=True
+        use6dtrack=True
     ):
         """."""
         self.acc = acc
-        if params is not None and params.use6dorb != use6dorb:
-            raise ValueError('Incompatible parameters use6dorb.')
+        if params is not None and params.use6dtrack != use6dtrack:
+            raise ValueError('Incompatible parameters use6dtrack.')
 
-        self.params = params or CorrParams(use6dorb=use6dorb)
+        self.params = params or CorrParams(use6dtrack=use6dtrack)
         self.respm = OrbRespmat(
             model=model,
             acc=self.acc,
-            use6dorb=use6dorb,
+            use6dtrack=use6dtrack,
             corr_system=corr_system
         )
         self.params.enbllistbpm = _np.ones(
@@ -269,7 +269,7 @@ class OrbitCorr:
 
     def get_orbit(self):
         """."""
-        if self.params.use6dorb:
+        if self.params.use6dtrack:
             cod = pyaccel.tracking.find_orbit6(
                 self.respm.model, indices='open')
         else:

--- a/apsuite/orbcorr/si_bumps.py
+++ b/apsuite/orbcorr/si_bumps.py
@@ -419,7 +419,7 @@ class SiCalcBumps:
             mod.cavity_on = True
         elif self.model.cavity_on is False:
             raise ValueError('Model cavity must be turned on!')
-        orbcorr = OrbitCorr(mod, 'SI', use6dorb=True)
+        orbcorr = OrbitCorr(mod, 'SI', use6dtrack=True)
         orbcorr.params.enblrf = True
         orbcorr.params.tolerance = 1e-9
         orbcorr.params.minsingval = minsingval
@@ -602,7 +602,7 @@ class SiCalcBumps:
             mod.cavity_on = True
         elif self.model.cavity_on is False:
             raise ValueError('Model cavity must be turned on!')
-        orbcorr = OrbitCorr(mod, 'SI', use6dorb=True)
+        orbcorr = OrbitCorr(mod, 'SI', use6dtrack=True)
         orbcorr.params.enblrf = True
         orbcorr.params.tolerance = 1e-9
         orbcorr.params.minsingval = 0.2

--- a/generic_scripts/fit_vertical_dispersion.py
+++ b/generic_scripts/fit_vertical_dispersion.py
@@ -48,7 +48,7 @@ def get_data_servconf_adjust_model(setup, find_best_alpha=True):
 
     simod = adjust_tunes(simod, setup)
     # Get nominal orbit matrix and dispersion
-    matrix_nominal = OrbRespmat(simod, 'SI', '6d').get_respm()
+    matrix_nominal = OrbRespmat(simod, 'SI', True).get_respm()
     alpha0 = pa.optics.get_mcf(simod)
 
     idx = pa.lattice.find_indices(simod, 'pass_method', 'cavity_pass')[0]


### PR DESCRIPTION
In PR https://github.com/lnls-fac/apsuite/pull/303, the string convention for specifying tracking dimension in `OrbitCorr` and `OrbRespmat` was replaced by a boolean flag: `dim="4D"` -> `use6dorb=False`. 

This PR propagates this new convention to other codes using these classes. Since `use6dorb` was quite specific for orbit and orbit correction contexts, this flag was renamed `use6dtrack` to be more generic, specifically because of its use in optics correction contexts (`LOCO`, `OpticsCorr`, `CouplingCorr`).