### PR TITLE
MNT.BUGFIX: Fix kick limit check by replacing duplicated "maskch" with "maskcv"

### DIFF
--- a/apsuite/orbcorr/orbit_correction.py
+++ b/apsuite/orbcorr/orbit_correction.py
@@ -359,7 +359,7 @@ class OrbitCorr:
             que = _np.max(que, axis=0)
             coef_ch = max(min(_np.min(que), coef_ch), 0)
 
-        if maskch.any():
+        if maskcv.any():
             que = [(-par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv]]
             que.append((par.maxkickcv - kickcv[maskcv]) / dkickcv[maskcv])
             que = _np.max(que, axis=0)


### PR DESCRIPTION
## Changes
- Replaced the duplicated `maskch` condition with `maskcv` in the second check.
