### PR TITLE
Select which BPMs to control in AcqBPMsSignals.

### DIFF
--- a/apsuite/commisslib/meas_bpms_signals.py
+++ b/apsuite/commisslib/meas_bpms_signals.py
@@ -90,13 +90,13 @@ class AcqBPMsSignals(_BaseClass):
     BPM_TRIGGER = "SI-Fam:TI-BPM"
     PSM_TRIGGER = "SI-Fam:TI-BPM-PsMtm"
 
-    def __init__(self, isonline=True, ispost_mortem=False):
+    def __init__(self, isonline=True, ispost_mortem=False, bpmnames=None):
         """."""
         super().__init__(params=AcqBPMsSignalsParams(), isonline=isonline)
         self._ispost_mortem = ispost_mortem
 
         if self.isonline:
-            self.create_devices()
+            self.create_devices(bpmnames=bpmnames)
 
     calc_positions_from_amplitudes = staticmethod(
         FamBPMs.calc_positions_from_amplitudes)
@@ -122,11 +122,12 @@ class AcqBPMsSignals(_BaseClass):
         self.data = data
         return ret
 
-    def create_devices(self):
+    def create_devices(self, bpmnames=None):
         """."""
         self.devices["currinfo"] = CurrInfoSI()
         self.devices["fambpms"] = FamBPMs(
             devname=FamBPMs.DEVICES.SI,
+            bpmnames=bpmnames,
             ispost_mortem=self._ispost_mortem,
             props2init="acq",
         )

--- a/apsuite/utils.py
+++ b/apsuite/utils.py
@@ -132,7 +132,7 @@ class MeasBaseClass(DataBaseClass):
 
     def __init__(self, params=None, isonline=True):
         """."""
-        super().__init__(params=params)
+        DataBaseClass.__init__(self, params=params)
         self.isonline = bool(isonline)
         self.devices = dict()
         self.analysis = dict()
@@ -170,7 +170,7 @@ class ThreadedMeasBaseClass(MeasBaseClass):
 
     def __init__(self, params=None, target=None, isonline=True):
         """."""
-        super().__init__(params=params, isonline=isonline)
+        MeasBaseClass.__init__(self, params=params, isonline=isonline)
         self._target = target
         self._stopevt = _Event()
         self._finished = _Event()


### PR DESCRIPTION
This PR adds the functionality of selecting which BPMs will be controlled during triggered acquisitions.

This feature proved very useful in acquisitions at ADCSwap rate, during measurements of the IVU impedance (see #330), where the data acquisition rate is very high, which compromises the integrity of the acquisitions with all BPMs. By splitting the BPMs in two groups, odd and even, we were able to increase the number of acquisition points from 1910 to 191000 without running into any halt and/or data integrity issues.